### PR TITLE
Forward generation to correct module.

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,3 +1,4 @@
+# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 srpm:
 	make -f "$(spec)/.copr/Makefile" srpm outdir="$(outdir)" spec="$(spec)"

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,7 @@
+
+srpm:
+	make -f "$(spec)/.copr/Makefile" srpm outdir="$(outdir)" spec="$(spec)"
+clean:
+	make -f "$(spec)/.copr/Makefile" clean outdir="$(outdir)" spec="$(spec)"
+
+.PHONY: srpm clean


### PR DESCRIPTION
Subdir for spec files not honoured by srpm generation. Need to have a forward mechanism.