### PR TITLE
Install all 3rd-party dependencies into /opt/vespa-deps and use /opt/…

### DIFF
--- a/boost/vespa-boost.spec.tmpl
+++ b/boost/vespa-boost.spec.tmpl
@@ -6,7 +6,7 @@
 %undefine _missing_build_ids_terminate_build
 
 # Force special prefix for Vespa
-%define _prefix /opt/vespa-boost
+%define _prefix /opt/vespa-deps
 
 # Version
 %define ver_major _TMPL_VER_MAJOR
@@ -74,19 +74,19 @@ source /opt/rh/devtoolset-7/enable || true
 export BOOST_LIBS="iostreams,filesystem,signals,program_options,regex,serialization,system,test,thread,timer,chrono"
 export CXXFLAGS="-std=c++14 -DNOT_BOOST_SPIRIT_THREADSAFE=1 -DNOT_PHOENIX_THREADSAFE=1 -DBOOST_NO_AUTO_PTR=1"
 ./bootstrap.sh --with-libraries=$BOOST_LIBS --prefix=%{buildroot}/%{_prefix} 
-./bjam -d+2 %{_smp_mflags} variant=release debug-symbols=on threading=multi link=shared runtime-link=shared dll-path=%{_prefix}/lib cxxflags=%{_cxxflags} --layout=versioned --prefix=%{buildroot}/%{_prefix}
+./bjam -d+2 %{_smp_mflags} variant=release debug-symbols=on threading=multi link=shared runtime-link=shared dll-path=%{_prefix}/lib64 cxxflags=%{_cxxflags} --layout=versioned --prefix=%{buildroot}/%{_prefix}
 
 %install
 
 rm -rf $RPM_BUILD_ROOT
 source /opt/rh/devtoolset-7/enable || true
-./bjam -d+2 %{_smp_mflags} variant=release debug-symbols=on threading=multi link=shared runtime-link=shared dll-path=%{_prefix}/lib cxxflags=%{_cxxflags} install --layout=versioned --prefix=%{buildroot}/%{_prefix}
+./bjam -d+2 %{_smp_mflags} variant=release debug-symbols=on threading=multi link=shared runtime-link=shared dll-path=%{_prefix}/lib64 cxxflags=%{_cxxflags} install --layout=versioned --prefix=%{buildroot}/%{_prefix}
 
 cd %{buildroot}/%{_includedir}
 mv boost-%{ver_major}_%{ver_minor}/boost .
 rm -rf boost-%{ver_major}_%{ver_mainor}
 
-cd %{buildroot}/%{_prefix}/lib
+cd %{buildroot}/%{_prefix}/lib64
 for i in $(ls *.so); do lnk=$(echo $i | sed "s/-gcc[0-9]*-/-/" | sed "s/-%{ver_major}_%{ver_minor}//"); ln -s $i $lnk; done
 for f in $(ls *\-mt.so); do ln -s "$f" "${f%.*}-d.so"; done
 
@@ -97,11 +97,11 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root,-)
 %doc
-%{_prefix}/lib/*.so*
+%{_prefix}/lib64/*.so*
 
 %files devel
 %defattr(-,root,root,-)
 %{_includedir}/boost
-%{_prefix}/lib/*.a
+%{_prefix}/lib64/*.a
 
 %changelog

--- a/cppunit/vespa-cppunit.spec.tmpl
+++ b/cppunit/vespa-cppunit.spec.tmpl
@@ -6,7 +6,7 @@
 %undefine _missing_build_ids_terminate_build
 
 # Force special prefix for Vespa
-%define _prefix /opt/vespa-cppunit
+%define _prefix /opt/vespa-deps
 
 # Version
 %define ver_major _TMPL_VER_MAJOR
@@ -79,8 +79,8 @@ This is a patched version for Vespa
 source %{_devtoolset_enable} || true
 %endif
 export CXXFLAGS="-std=c++14 -g -O3"
-export LDFLAGS="-Wl,-rpath,%{_prefix}/lib"
-./configure --prefix=%{_prefix}
+export LDFLAGS="-Wl,-rpath,%{_prefix}/lib64"
+./configure --prefix=%{_prefix} --libdir=%{_prefix}/lib64
 make %{_smp_mflags}
 
 %install
@@ -97,15 +97,15 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root,-)
-%{_prefix}/lib/*.so*
+%{_prefix}/lib64/*.so*
 
 %files devel
 %defattr(-,root,root,-)
 %{_includedir}/*
 %{_prefix}/bin/*
-%{_prefix}/lib/*.a 
-%{_prefix}/lib/*.la 
-%{_prefix}/lib/pkgconfig/*.pc
+%{_prefix}/lib64/*.a
+%{_prefix}/lib64/*.la
+%{_prefix}/lib64/pkgconfig/*.pc
 %{_prefix}/share/*               
 
 %changelog

--- a/gtest/vespa-gtest.spec.tmpl
+++ b/gtest/vespa-gtest.spec.tmpl
@@ -4,7 +4,7 @@
 %undefine _missing_build_ids_terminate_build
 
 # Force special prefix for Vespa
-%define _prefix /opt/vespa-gtest
+%define _prefix /opt/vespa-deps
 
 # Version
 %define ver_major _TMPL_VER_MAJOR


### PR DESCRIPTION
…vespa-deps/lib64 as libdir.

@aressem please review
Note that bootstrap-cmake.sh and dist/vespa.spec in vespa was prepared for this when adding protobuf dependency.

@toregge @vekterli @havardpe @baldersheim @arnej27959 @hakonhall FYI