### PR TITLE
upgrade onnx runtime to 1.7.1

### DIFF
--- a/onnxruntime/.copr/Makefile
+++ b/onnxruntime/.copr/Makefile
@@ -3,8 +3,8 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Version
 MAJOR=1
-MINOR=4
-PATCH=0
+MINOR=7
+PATCH=1
 RELEASE=1
 
 RPMTOPDIR=$(TOP)/rpmbuild


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

We need opset 13 to be able to use bfloat16/int8

@toregge @aressem please review
@arnej27959 FYI
