### PR TITLE
Copr no longer allow protocols that are not encrypted. Switch to https.

### DIFF
--- a/valgrind/vespa-valgrind.spec.tmpl
+++ b/valgrind/vespa-valgrind.spec.tmpl
@@ -18,7 +18,7 @@ Version:        %{ver_major}.%{ver_minor}.%{ver_patch}
 Release:        %{ver_release}%{?dist}
 License:        GPLv2+
 URL:            http://www.valgrind.org/
-Source0:        ftp://sourceware.org/pub/valgrind/valgrind-%{version}.tar.bz2
+Source0:        https://sourceware.org/pub/valgrind/valgrind-%{version}.tar.bz2
 
 
 %define _devtoolset_enable /opt/rh/devtoolset-9/enable


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
