### PR TITLE
Filter away broken require, we don't need libzstd rpm when we already

### DIFF
--- a/zstd/vespa-zstd.spec.tmpl
+++ b/zstd/vespa-zstd.spec.tmpl
@@ -12,6 +12,8 @@
 # Don't provide shared library or pkgconfig
 %global __provides_exclude ^(lib.*\\.so\\.[0-9]*\\(\\)\\(64bit\\)|pkgconfig\\(.*)$
 
+%global __requires_exclude ^libzstd\\.so\\.[0-9.]*\\([A-Z._0-9]*\\)\\(64bit\\)$
+
 # Version
 %define ver_major _TMPL_VER_MAJOR
 %define ver_minor _TMPL_VER_MINOR


### PR DESCRIPTION
require vespa-libzstd.

@baldersheim : please review
