### PR TITLE
Use devtoolset-10 and gcc-toolset-10 when available.

### DIFF
--- a/onnxruntime/vespa-onnxruntime.spec.tmpl
+++ b/onnxruntime/vespa-onnxruntime.spec.tmpl
@@ -35,23 +35,30 @@ Patch1:         patches.normalize-include.diff
 BuildRequires: gcc10-c++%{?_isa}
 %define _toolset_compiler_cmake_args CMAKE_C_COMPILER=gcc10-gcc CMAKE_CXX_COMPILER=gcc10-g++
 %else
-%define _devtoolset_enable /opt/rh/devtoolset-9/enable
-BuildRequires: devtoolset-9-gcc-c++%{?_isa}
+%define _devtoolset_enable /opt/rh/devtoolset-10/enable
+BuildRequires: devtoolset-10-gcc-c++%{?_isa}
 %endif
 BuildRequires: cmake3
 %define _cmake_prog cmake3
 %define _ctest_prog ctest3
 %endif
 %if 0%{?el8}
-%define _devtoolset_enable /opt/rh/gcc-toolset-9/enable
-BuildRequires: gcc-toolset-9-gcc-c++
+%define _devtoolset_enable /opt/rh/gcc-toolset-10/enable
+BuildRequires: gcc-toolset-10-gcc-c++
 BuildRequires: make
 BuildRequires: glibc-langpack-en
 BuildRequires: wget
+%if 0%{?centos:1}%{?rocky:1}
+BuildRequires: cmake
+%define _cmake_prog cmake
+%define _ctest_prog ctest
+%else
 %define _cmake_version 3.18.2
 %define _cmake_prefix $(pwd)/cmake-%{_cmake_version}-Linux-x86_64
 %define _cmake_prog %{_cmake_prefix}/bin/cmake
 %define _ctest_prog %{_cmake_prefix}/bin/ctest
+%define _download_cmake_tar 1
+%endif
 %endif
 %if 0%{?fedora}
 BuildRequires: gcc-c++
@@ -95,8 +102,8 @@ about packaging.
 %patch0 -p0
 %patch1 -p1
 
-%if 0%{?el8}
-# Download precompiled cmake version on CentOS 8 and RHEL 8 for now.
+%if 0%{?_download_cmake_tar}
+# Download precompiled cmake version on RHEL 8.3 for now.
 if test -f %{cmake_prog}
 then
   :


### PR DESCRIPTION
No need to download cmake tar file on CentOS 8 and Rocky Linux 8.4.

@baldersheim : please review
