### PR TITLE
Bump OpenSSL version to 1.1.1l patch release

### DIFF
--- a/openssl/.copr/Makefile
+++ b/openssl/.copr/Makefile
@@ -4,7 +4,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 # Version
 MAJOR=1
 MINOR=1
-PATCH=1k
+PATCH=1l
 RELEASE=1
 
 RPMTOPDIR=$(TOP)/rpmbuild


### PR DESCRIPTION
@aressem please review. No known vulnerabilities fixed that affect Vespa's use of OpenSSL.