### PR TITLE
Perl required when compiling openssl on CentOS 8.

### DIFF
--- a/openssl/vespa-openssl.spec.tmpl
+++ b/openssl/vespa-openssl.spec.tmpl
@@ -40,6 +40,7 @@ BuildRequires: devtoolset-10-gcc-c++%{?_isa}
 %define _devtoolset_enable /opt/rh/gcc-toolset-10/enable
 BuildRequires: gcc-toolset-10-gcc-c++
 BuildRequires: make
+BuildRequires: perl
 %endif
 %if 0%{?fedora}
 BuildRequires: gcc-c++


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
