### PR TITLE
Disable pybind11 tests when packaging RPM for aarch64 el8.

### DIFF
--- a/pybind11/vespa-pybind11.spec.tmpl
+++ b/pybind11/vespa-pybind11.spec.tmpl
@@ -41,7 +41,9 @@ BuildRequires: python36-pytest
 BuildRequires: python36-scipy
 %endif
 %define _cmake_download_catch -DDOWNLOAD_CATCH=ON
+%define _cmake_pybind11_test -DPYBIND11_TEST=ON
 %endif
+
 %if 0%{?el8}
 %define _devtoolset_enable /opt/rh/gcc-toolset-9/enable
 BuildRequires: gcc-toolset-9-gcc-c++
@@ -51,7 +53,13 @@ BuildRequires: boost-devel
 BuildRequires: python3-pytest
 BuildRequires: python3-scipy
 %define _cmake_download_catch -DDOWNLOAD_CATCH=ON
+%ifarch aarch64
+%define _cmake_pybind11_test -DPYBIND11_TEST=OFF
+%else
+%define _cmake_pybind11_test -DPYBIND11_TEST=ON
 %endif
+%endif
+
 %if 0%{?fedora}
 BuildRequires: gcc-c++
 BuildRequires: make
@@ -103,13 +111,14 @@ echo includedir is %{_includedir}
 mkdir build
 cd build
 
+
 %{?_cmake_prog}%{!?_cmake_prog:cmake} \
   -DCMAKE_PREFIX_PATH=${_prefix} \
   -DCMAKE_INSTALL_PREFIX=%{_prefix} \
   -DCMAKE_INSTALL_RPATH=%{_libdir}  \
   -DCMAKE_BUILD_WITH_INSTALL_RPATH=true \
-  -DPYBIND11_TEST=ON \
   -DCMAKE_CXX_STANDARD=17 \
+  %{_cmake_pybind11_test} \
   %{_cmake_download_catch} \
   %{?_toolset_compiler_cmake_args} \
   ..


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
