### PR TITLE
Use gcc-toolset-11 when compiling gtest for CentOS Stream 8

### DIFF
--- a/gtest/vespa-gtest.spec.tmpl
+++ b/gtest/vespa-gtest.spec.tmpl
@@ -42,10 +42,18 @@ BuildRequires: cmake3
 %define _cmake_prog cmake3
 %endif
 %if 0%{?el8}
+%global _centos_stream %(grep -qs '^NAME="CentOS Stream"' /etc/os-release && echo 1 || echo 0)
+%if 0%{?_centos_stream} || 0%{?rocky} || 0%{?almalinux}
+BuildRequires: gcc-toolset-11-gcc-c++
+BuildRequires: gcc-toolset-11-annobin
+BuildRequires: gcc-toolset-11-annobin-plugin-gcc
+%define _devtoolset_enable /opt/rh/gcc-toolset-11/enable
+%else
 %define _devtoolset_enable /opt/rh/gcc-toolset-10/enable
-BuildRequires: cmake
 BuildRequires: gcc-toolset-10-gcc-c++
 BuildRequires: gcc-toolset-10-annobin
+%endif
+BuildRequires: cmake
 %endif
 %if 0%{?fedora}
 BuildRequires: cmake


### PR DESCRIPTION
Rocky Linux 8.5 and AlmaLinux 8.5.

@baldersheim : please review
