### PR TITLE
Build pybind11 on CentOS Stream 9.

### DIFF
--- a/pybind11/.copr/Makefile
+++ b/pybind11/.copr/Makefile
@@ -17,6 +17,7 @@ srpm:
 	mkdir -p $(SPECDIR) $(SOURCEDIR)
 	cat vespa-pybind11.spec.tmpl | sed "s/_TMPL_VER_MAJOR/$(MAJOR)/" | sed "s/_TMPL_VER_MINOR/$(MINOR)/" | sed "s/_TMPL_VER_PATCH/$(PATCH)/" | sed "s/_TMPL_VER_RELEASE/$(RELEASE)/" > $(SPECFILE)
 	spectool -g -C $(SOURCEDIR) $(SPECFILE)
+	cp -a *.diff $(SOURCEDIR)
 	rpmbuild -bs --define "_topdir $(RPMTOPDIR)" $(SPECFILE)
 	cp -a $(RPMTOPDIR)/SRPMS/* $(outdir)
 clean:

--- a/pybind11/patches.use-newer-catch.diff
+++ b/pybind11/patches.use-newer-catch.diff
@@ -1,0 +1,11 @@
+--- tests/test_embed/CMakeLists.txt.FCS	2021-10-27 21:35:10.000000000 +0000
++++ tests/test_embed/CMakeLists.txt	2021-12-15 10:16:24.959326412 +0000
+@@ -7,7 +7,7 @@
+   return()
+ endif()
+ 
+-find_package(Catch 2.13.2)
++find_package(Catch 2.13.7)
+ 
+ if(CATCH_FOUND)
+   message(STATUS "Building interpreter tests using Catch v${CATCH_VERSION}")

--- a/pybind11/vespa-pybind11.spec.tmpl
+++ b/pybind11/vespa-pybind11.spec.tmpl
@@ -22,6 +22,7 @@ Release:        %{ver_release}%{?dist}
 License:        BSD
 URL:            https://github.com/pybind/pybind11
 Source0:        https://github.com/pybind/pybind11/archive/refs/tags/v%{version}.tar.gz
+Patch0:         patches.use-newer-catch.diff
 
 %if 0%{?el7}
 %if 0%{?amzn2}
@@ -101,6 +102,9 @@ python3 -m pip install --user --upgrade pytest
 python3 -m pip install --user scipy
 %endif
 %setup -q -n pybind11-%{version}
+%if 0%{?el9} || 0%{?fedora}
+%patch0 -p0
+%endif
 
 %build
 echo building at $(pwd)
@@ -119,7 +123,7 @@ env %{?_cmake_env} %{?_cmake_prog}%{!?_cmake_prog:cmake} \
   -DCMAKE_INSTALL_PREFIX=%{_prefix} \
   -DCMAKE_INSTALL_RPATH=%{_libdir}  \
   -DCMAKE_BUILD_WITH_INSTALL_RPATH=true \
-  -DPYBIND11_TEST=%{?el9:OFF}%{!?el9:ON} \
+  -DPYBIND11_TEST=ON \
   -DCMAKE_CXX_STANDARD=17 \
   %{_cmake_download_catch} \
   %{?_toolset_compiler_cmake_args} \
@@ -129,11 +133,9 @@ env %{?_cmake_env} %{?_cmake_prog}%{!?_cmake_prog:cmake} \
 
 %check
 cd build
-%if ! 0%{?el9}
 make %{_smp_mflags} pytest
 make %{_smp_mflags} cpptest
 make %{_smp_mflags} test_cmake_build
-%endif
 
 %install
 %if 0%{?_devtoolset_enable:1}

--- a/pybind11/vespa-pybind11.spec.tmpl
+++ b/pybind11/vespa-pybind11.spec.tmpl
@@ -55,6 +55,14 @@ BuildRequires: python3-pytest
 BuildRequires: python3-scipy
 %define _cmake_download_catch -DDOWNLOAD_CATCH=ON
 %endif
+%if 0%{?el9}
+BuildRequires: gcc-c++
+BuildRequires: cmake
+BuildRequires: boost-devel
+BuildRequires: python3-pytest
+BuildRequires: python3-scipy
+%define _cmake_download_catch -DDOWNLOAD_CATCH=ON
+%endif
 %if 0%{?fedora}
 BuildRequires: gcc-c++
 BuildRequires: cmake
@@ -111,7 +119,7 @@ env %{?_cmake_env} %{?_cmake_prog}%{!?_cmake_prog:cmake} \
   -DCMAKE_INSTALL_PREFIX=%{_prefix} \
   -DCMAKE_INSTALL_RPATH=%{_libdir}  \
   -DCMAKE_BUILD_WITH_INSTALL_RPATH=true \
-  -DPYBIND11_TEST=ON \
+  -DPYBIND11_TEST=%{?el9:OFF}%{!?el9:ON} \
   -DCMAKE_CXX_STANDARD=17 \
   %{_cmake_download_catch} \
   %{?_toolset_compiler_cmake_args} \
@@ -121,9 +129,11 @@ env %{?_cmake_env} %{?_cmake_prog}%{!?_cmake_prog:cmake} \
 
 %check
 cd build
+%if ! 0%{?el9}
 make %{_smp_mflags} pytest
 make %{_smp_mflags} cpptest
 make %{_smp_mflags} test_cmake_build
+%endif
 
 %install
 %if 0%{?_devtoolset_enable:1}


### PR DESCRIPTION
Disable tests when building on CentOS Stream 9.
