### PR TITLE
Update OpenSSL to 1.1.1o patch version

### DIFF
--- a/openssl/.copr/Makefile
+++ b/openssl/.copr/Makefile
@@ -4,7 +4,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 # Version
 MAJOR=1
 MINOR=1
-PATCH=1n
+PATCH=1o
 RELEASE=1
 
 RPMTOPDIR=$(TOP)/rpmbuild


### PR DESCRIPTION
@aressem please review
@bjorncs FYI

From what I can see, Vespa is not affected by any security bugs fixed as part of this release (https://www.openssl.org/news/secadv/20220503.txt). But let's use the most freshly squeezed release anyway.
