### PR TITLE
skip tests when building onnxruntime

### DIFF
--- a/onnxruntime/vespa-onnxruntime.spec.tmpl
+++ b/onnxruntime/vespa-onnxruntime.spec.tmpl
@@ -126,7 +126,7 @@ source %{_devtoolset_enable} || true
 %endif
 
 PATH=%{_prefix}/bin:$PATH
-./build.sh --config RelWithDebInfo --build_java --build_shared_lib --parallel --cmake_path %{_cmake_prog} --ctest_path %{_ctest_prog} --skip_submodule_sync --cmake_extra_defines CMAKE_INSTALL_PREFIX=%{_prefix} onnxruntime_DEV_MODE=OFF onnxruntime_USE_OPENMP=OFF %{?_toolset_compiler_cmake_args}
+./build.sh --config RelWithDebInfo  --skip_tests --build_java --build_shared_lib --parallel --cmake_path %{_cmake_prog} --ctest_path %{_ctest_prog} --skip_submodule_sync --cmake_extra_defines CMAKE_INSTALL_PREFIX=%{_prefix} onnxruntime_DEV_MODE=OFF onnxruntime_USE_OPENMP=OFF %{?_toolset_compiler_cmake_args}
 
 %install
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
* avoids problem when cross-building for aarch64

@aressem please review
