### PR TITLE
Adjust gradle and onnxruntime rpm spec files for Fedora, Amazon Linux 2022

### DIFF
--- a/gradle/vespa-gradle.spec.tmpl
+++ b/gradle/vespa-gradle.spec.tmpl
@@ -20,10 +20,15 @@ Release:        %{ver_release}%{?dist}
 License:        Apache
 URL:            https://gradle.org/
 Source0:        https://services.gradle.org/distributions/gradle-%{version}-bin.zip
-Patch0:         script.sh
+Source1:        script.sh
 
-%if 0%{?el7} || 0%{?el8}
+%if 0%{?amzn2022}
+Requires: java-11-amazon-corretto-devel
+Requires: java-11-amazon-corretto
+%else
+%if 0%{?el7} || 0%{?el8} || 0%{?el9} || 0%{?fedora}
 Requires: java-11-openjdk-devel
+%endif
 %endif
 
 %global _vespa_3rdparty_deps_packaging_notice \
@@ -45,7 +50,7 @@ about packaging.
 mkdir -p %{buildroot}%{_gdir}
 cp -R . %{buildroot}%{_gdir}/.
 mkdir -p %{buildroot}%{_prefix}/bin
-cp -p %{_sourcedir}/script.sh %{buildroot}%{_prefix}/bin/gradle
+cp -p %{SOURCE1} %{buildroot}%{_prefix}/bin/gradle
 
 %files
 %{_prefix}/bin/

--- a/onnxruntime/.copr/Makefile
+++ b/onnxruntime/.copr/Makefile
@@ -36,6 +36,7 @@ endif
 	tar -C $(SRCTMPBASE) -czf $(SOURCEDIR)/vespa-onnxruntime-$(VERSION).tar.gz vespa-onnxruntime-$(VERSION)
 	rm -rf $(SRCTMPBASE)
 	cat vespa-onnxruntime.spec.tmpl | sed "s/_TMPL_VER_MAJOR/$(MAJOR)/" | sed "s/_TMPL_VER_MINOR/$(MINOR)/" | sed "s/_TMPL_VER_PATCH/$(PATCH)/" | sed "s/_TMPL_VER_RELEASE/$(RELEASE)/" > $(SPECFILE)
+	cp -a *.diff $(SOURCEDIR)
 	rpmbuild -bs --define "_topdir $(RPMTOPDIR)" $(SPECFILE)
 	cp -a $(RPMTOPDIR)/SRPMS/* $(outdir)
 clean:

--- a/onnxruntime/patches.use-origin-rpath-for-jni-library.diff
+++ b/onnxruntime/patches.use-origin-rpath-for-jni-library.diff
@@ -1,0 +1,12 @@
+diff --git a/cmake/onnxruntime_java.cmake b/cmake/onnxruntime_java.cmake
+index d7b47f699..542f72b6f 100644
+--- a/cmake/onnxruntime_java.cmake
++++ b/cmake/onnxruntime_java.cmake
+@@ -61,6 +61,7 @@ file(GLOB onnxruntime4j_native_src
+ # Build the JNI library
+ onnxruntime_add_shared_library_module(onnxruntime4j_jni ${onnxruntime4j_native_src})
+ set_property(TARGET onnxruntime4j_jni PROPERTY CXX_STANDARD 11)
++set_target_properties(onnxruntime4j_jni PROPERTIES BUILD_RPATH_USE_ORIGIN TRUE)
+ 
+ # depend on java sources. if they change, the JNI should recompile
+ add_dependencies(onnxruntime4j_jni onnxruntime4j)

--- a/onnxruntime/vespa-onnxruntime.spec.tmpl
+++ b/onnxruntime/vespa-onnxruntime.spec.tmpl
@@ -10,7 +10,7 @@
 %global _find_debuginfo_opts -g
 
 # Don't provide shared library or pkgconfig
-%global __provides_exclude ^(lib.*\\.so\\.[0-9.]*\\([A-Z._0-9]*\\)\\(64bit\\)|pkgconfig\\(.*)$
+%global __provides_exclude ^(lib.*\\.so(\\.[0-9.]*)?\\([A-Z._0-9]*\\)\\(64bit\\)|pkgconfig\\(.*)$
 
 %global __requires_exclude ^libonnxruntime\\.so\\.[0-9.]*\\([A-Z._0-9]*\\)\\(64bit\\)$
 
@@ -28,8 +28,9 @@ License:        MIT License
 URL:            https://microsoft.github.io/onnxruntime
 Source0:        vespa-onnxruntime-%{version}.tar.gz
 
-%if 0%{?el7}
 BuildRequires: vespa-gradle
+BuildRequires: which
+%if 0%{?el7}
 %if 0%{?amzn2}
 BuildRequires: gcc10-c++%{?_isa}
 %define _toolset_compiler_cmake_args CMAKE_C_COMPILER=gcc10-gcc CMAKE_CXX_COMPILER=gcc10-g++
@@ -45,7 +46,6 @@ BuildRequires: wget
 %define _download_cmake_tar 1
 %endif
 %if 0%{?el8}
-BuildRequires: vespa-gradle
 %define _devtoolset_enable /opt/rh/gcc-toolset-11/enable
 BuildRequires: gcc-toolset-11-gcc-c++
 BuildRequires: make
@@ -72,7 +72,7 @@ BuildRequires: glibc-langpack-en
 %define _ctest_prog ctest
 %endif
 BuildRequires: zlib-devel
-%if ! 0%{?el9}
+%if ! 0%{?el9} && ! 0%{?amzn2022}
 BuildRequires: redhat-lsb-core
 %endif
 BuildRequires: expat-devel

--- a/onnxruntime/vespa-onnxruntime.spec.tmpl
+++ b/onnxruntime/vespa-onnxruntime.spec.tmpl
@@ -27,6 +27,7 @@ Release:        %{ver_release}%{?dist}
 License:        MIT License
 URL:            https://microsoft.github.io/onnxruntime
 Source0:        vespa-onnxruntime-%{version}.tar.gz
+Patch0:         patches.use-origin-rpath-for-jni-library.diff
 
 BuildRequires: vespa-gradle
 BuildRequires: which
@@ -106,6 +107,7 @@ See https://github.com/vespa-engine/vespa-3rdparty-deps for details
 about packaging.
 %prep
 %setup -q
+%patch0 -p1
 
 %if 0%{?_download_cmake_tar}
 # Download precompiled cmake version on CentOS 7, RHEL 7 and Amazon Linux 2 for now.


### PR DESCRIPTION
and CentOS Stream 9.

@arnej27959 : please review
@aressem : FYI
