### PR TITLE
Add -fPIE gcc option when compiling vespa-lz4 on Amazon Linux 2022.

### DIFF
--- a/lz4/vespa-lz4.spec.tmpl
+++ b/lz4/vespa-lz4.spec.tmpl
@@ -51,6 +51,9 @@ BuildRequires: gcc
 %define _extra_gcc_opt -fPIE
 %endif
 %endif
+%if 0%{?amzn2022}
+%define _extra_gcc_opt -fPIE
+%endif
 BuildRequires: make
 
 %global _vespa_3rdparty_deps_packaging_notice \


### PR DESCRIPTION
@aressem : please review
