### PR TITLE
Must use go (>=1.4) to build go (since go 1.5)

### DIFF
--- a/wireguard-go/vespa-wireguard-go.spec.tmpl
+++ b/wireguard-go/vespa-wireguard-go.spec.tmpl
@@ -23,6 +23,7 @@ Source0:        https://github.com/WireGuard/wireguard-go/archive/refs/tags/%{ve
 Source1:        https://github.com/golang/go/archive/refs/tags/%{go_tag}.zip
 BuildRequires:  git
 BuildRequires:  make
+BuildRequires:  golang
 
 %description
 Wireguard-go built for Vespa.


### PR DESCRIPTION
FYI: @aressem 