### PR TITLE
Prepare for OpenSSL 1.1.1t release

### DIFF
--- a/openssl/.copr/Makefile
+++ b/openssl/.copr/Makefile
@@ -4,8 +4,8 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 # Version
 MAJOR=1
 MINOR=1
-PATCH=1o
-RELEASE=2
+PATCH=1t
+RELEASE=1
 
 RPMTOPDIR=$(TOP)/rpmbuild
 SOURCEDIR=$(RPMTOPDIR)/SOURCES


### PR DESCRIPTION
Not yet released, but let's be ready for when it drops (at some point tomorrow Feb 7th between 1300 and 1700 UTC).

@bjorncs please review
@aressem FYI