### PR TITLE
Update vespa-openblas to version 0.3.23.

### DIFF
--- a/openblas/.copr/Makefile
+++ b/openblas/.copr/Makefile
@@ -4,8 +4,8 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 # Version
 MAJOR=0
 MINOR=3
-PATCH=21
-RELEASE=2
+PATCH=23
+RELEASE=1
 
 RPMTOPDIR=$(TOP)/rpmbuild
 SOURCEDIR=$(RPMTOPDIR)/SOURCES
@@ -17,6 +17,7 @@ srpm:
 	mkdir -p $(SPECDIR) $(SOURCEDIR)
 	cat vespa-openblas.spec.tmpl | sed "s/_TMPL_VER_MAJOR/$(MAJOR)/" | sed "s/_TMPL_VER_MINOR/$(MINOR)/" | sed "s/_TMPL_VER_PATCH/$(PATCH)/" | sed "s/_TMPL_VER_RELEASE/$(RELEASE)/" > $(SPECFILE)
 	spectool -g -C $(SOURCEDIR) $(SPECFILE)
+	cp -a *.diff $(SOURCEDIR)
 	rpmbuild -bs --define "_topdir $(RPMTOPDIR)" $(SPECFILE)
 	cp -a $(RPMTOPDIR)/SRPMS/* $(outdir)
 clean:

--- a/openblas/patches.driver-others-dynamic-arm64.diff
+++ b/openblas/patches.driver-others-dynamic-arm64.diff
@@ -1,0 +1,14 @@
+--- driver/others/dynamic_arm64.c.FCS	2023-04-01 22:18:01.000000000 +0200
++++ driver/others/dynamic_arm64.c	2023-06-29 19:02:46.402670342 +0200
+@@ -242,7 +242,10 @@
+         p = (char *) NULL ;
+ 	infile = fopen("/sys/devices/system/cpu/cpu0/regs/identification/midr_el1","r");
+ 	if (!infile) return NULL;
+-	(void)fgets(buffer, sizeof(buffer), infile);
++	if (fgets(buffer, sizeof(buffer), infile) == NULL) {
++            fclose(infile);
++            return NULL;
++        }
+ 	midr_el1=strtoul(buffer,NULL,16);
+ 	fclose(infile);
+ #else

--- a/openblas/vespa-openblas.spec.tmpl
+++ b/openblas/vespa-openblas.spec.tmpl
@@ -27,11 +27,17 @@ Release:        %{ver_release}%{?dist}
 License:        BSD
 URL:            https://github.com/xianyi/OpenBLAS/
 Source0:        https://github.com/xianyi/OpenBLAS/archive/v%{version}/openblas-%{version}.tar.gz
+Patch0:         patches.driver-others-dynamic-arm64.diff
 
-%if 0%{?el8}%{?el9}
+%if 0%{?el8}
+%define _devtoolset_enable /opt/rh/gcc-toolset-11/enable
+BuildRequires: vespa-toolset-11-meta
+BuildRequires: gcc-toolset-11-gcc-gfortran
+BuildRequires: perl-devel
+%endif
+%if 0%{?el9}
 %define _devtoolset_enable /opt/rh/gcc-toolset-12/enable
-BuildRequires: gcc-toolset-12-gcc
-BuildRequires: gcc-toolset-12-gcc-c++
+BuildRequires: vespa-toolset-12-meta
 BuildRequires: gcc-toolset-12-gcc-gfortran
 BuildRequires: perl-devel
 %endif
@@ -59,6 +65,7 @@ openblas compiled for vespa -- devel
 %{_vespa_3rdparty_deps_packaging_notice}
 %prep
 %setup -n OpenBLAS-%{version}
+%patch0 -p0
 
 %build
 %if 0%{?_devtoolset_enable:1}


### PR DESCRIPTION
@aressem : please review

Version bumped to 0.3.23. Downgrade to gcc-toolset-11 to avoid further errors in valgrind when decoding ELF sections.
