### PR TITLE
Move to OpenSSL 3.1

### DIFF
--- a/openssl/.copr/Makefile
+++ b/openssl/.copr/Makefile
@@ -2,9 +2,9 @@
 TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Version
-MAJOR=1
+MAJOR=3
 MINOR=1
-PATCH=1t
+PATCH=2
 RELEASE=1
 
 RPMTOPDIR=$(TOP)/rpmbuild

--- a/openssl/vespa-openssl.spec.tmpl
+++ b/openssl/vespa-openssl.spec.tmpl
@@ -83,11 +83,11 @@ cd build
 %{_prefix}/lib64/
 %{_prefix}/conf/ssl/
 %{_prefix}/share/man/
-%license LICENSE
+%license LICENSE.txt
 
 %files devel
 %{_prefix}/include/
 %{_prefix}/lib64/pkgconfig/
-%license LICENSE
+%license LICENSE.txt
 
 %changelog


### PR DESCRIPTION
@aressem please review

OpenSSL 1.1.x is officially EOL in a few weeks. 3.1.2 is the latest 3.1 release.

Only minor change to the build process is that `LICENSE` has been moved to `LICENSE.txt` on the 3 (and also `master`) branch.

No changes should be required in the main Vespa code base, as it has long since been upgraded to use 1.1.x APIs, and 3.1 is API-compatible. Have manually tested RPM building and that Vespa builds cleanly with 3.1.
