### PR TITLE
Upgrade java-llama to 3.0.0

### DIFF
--- a/jllama-cuda/.copr/Makefile
+++ b/jllama-cuda/.copr/Makefile
@@ -3,9 +3,9 @@
 TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Version
-MAJOR=2
-MINOR=3
-PATCH=5
+MAJOR=3
+MINOR=0
+PATCH=0
 RELEASE=1
 PKGNAME=vespa-jllama-cuda
 

--- a/jllama/.copr/Makefile
+++ b/jllama/.copr/Makefile
@@ -3,9 +3,9 @@
 TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Version
-MAJOR=2
-MINOR=3
-PATCH=5
+MAJOR=3
+MINOR=0
+PATCH=0
 RELEASE=1
 PKGNAME=vespa-jllama
 


### PR DESCRIPTION
@arnej27959 Please review. Anything else that needs to be updated for this upgrade? Except of course the version number in Vespa, that will be another PR.