### PR TITLE
depend on multithreaded openblas

### DIFF
--- a/jllama-cuda/.copr/Makefile
+++ b/jllama-cuda/.copr/Makefile
@@ -6,7 +6,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 MAJOR=3
 MINOR=0
 PATCH=1
-RELEASE=8
+RELEASE=9
 PKGNAME=vespa-jllama-cuda
 
 RPMTOPDIR=$(TOP)/rpmbuild

--- a/jllama-cuda/vespa-jllama-cuda.spec.tmpl
+++ b/jllama-cuda/vespa-jllama-cuda.spec.tmpl
@@ -11,7 +11,7 @@
 # Don't provide shared library or pkgconfig
 %global __provides_exclude ^(lib.*\\.so\\.[0-9]*\\(\\)\\(64bit\\)|(cmake|pkgconfig)\\(.*)$
 
-%global __requires_exclude ^lib.*lama\.so\\.[0-9.]*\\([A-Z._0-9]*\\)\\(64bit\\)$
+%global __requires_exclude ^lib(jllama|llama|openblas|openblasp)\.so[0-9.]*\\([A-Z._0-9]*\\)\\(64bit\\)$
 
 # Version
 %define ver_major _TMPL_VER_MAJOR

--- a/jllama-cuda/vespa-jllama-cuda.spec.tmpl
+++ b/jllama-cuda/vespa-jllama-cuda.spec.tmpl
@@ -8,6 +8,11 @@
 
 %global debug_package %{nil}
 
+# Don't provide shared library or pkgconfig
+%global __provides_exclude ^(lib.*\\.so\\.[0-9]*\\(\\)\\(64bit\\)|(cmake|pkgconfig)\\(.*)$
+
+%global __requires_exclude ^lib.*lama\.so\\.[0-9.]*\\([A-Z._0-9]*\\)\\(64bit\\)$
+
 # Version
 %define ver_major _TMPL_VER_MAJOR
 %define ver_minor _TMPL_VER_MINOR

--- a/jllama-cuda/vespa-jllama-cuda.spec.tmpl
+++ b/jllama-cuda/vespa-jllama-cuda.spec.tmpl
@@ -9,7 +9,7 @@
 %global debug_package %{nil}
 
 # Don't provide shared library or pkgconfig
-%global __provides_exclude ^(lib.*\\.so\\.[0-9]*\\(\\)\\(64bit\\)|(cmake|pkgconfig)\\(.*)$
+%global __provides_exclude ^(lib.*\\.so[0-9.]*\\(\\)\\(64bit\\)|(cmake|pkgconfig)\\(.*)$
 
 %global __requires_exclude ^lib(jllama|llama|openblas|openblasp)\.so[0-9.]*\\([A-Z._0-9]*\\)\\(64bit\\)$
 

--- a/jllama-cuda/vespa-jllama-cuda.spec.tmpl
+++ b/jllama-cuda/vespa-jllama-cuda.spec.tmpl
@@ -14,6 +14,8 @@
 %define ver_patch _TMPL_VER_PATCH
 %define ver_release _TMPL_VER_RELEASE
 
+%global _vespa_openblas_version 0.3.27
+
 Summary:        Native part of Java Bindings for llama.cpp using CUDA
 Name:           vespa-jllama-cuda
 Version:        %{ver_major}.%{ver_minor}.%{ver_patch}
@@ -35,6 +37,9 @@ BuildRequires: cuda-compiler-12-2
 BuildRequires: cuda-cudart-devel-12-2
 BuildRequires: cuda-command-line-tools-12-2
 %endif
+
+BuildRequires: vespa-openblas-devel >= %{_vespa_openblas_version}
+Requires: vespa-openblas >= %{_vespa_openblas_version}
 
 BuildRequires: vespa-cmake
 BuildRequires: make
@@ -66,6 +71,7 @@ cmake  \
     -DCMAKE_INSTALL_RPATH=\$ORIGIN \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH=true \
     -DLLAMA_NATIVE=OFF \
+    -DLLAMA_BLAS=ON -DLLAMA_BLAS_VENDOR=OpenBLAS \
     -DLLAMA_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="60;70;75" \
     ..
 cmake --build . --config Release

--- a/jllama/.copr/Makefile
+++ b/jllama/.copr/Makefile
@@ -6,7 +6,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 MAJOR=3
 MINOR=0
 PATCH=1
-RELEASE=8
+RELEASE=9
 PKGNAME=vespa-jllama
 
 RPMTOPDIR=$(TOP)/rpmbuild

--- a/jllama/vespa-jllama.spec.tmpl
+++ b/jllama/vespa-jllama.spec.tmpl
@@ -11,7 +11,7 @@
 # Don't provide shared library or pkgconfig
 %global __provides_exclude ^(lib.*\\.so\\.[0-9]*\\(\\)\\(64bit\\)|(cmake|pkgconfig)\\(.*)$
 
-%global __requires_exclude ^lib.*lama\.so\\.[0-9.]*\\([A-Z._0-9]*\\)\\(64bit\\)$
+%global __requires_exclude ^lib(jllama|llama|openblas|openblasp)\.so[0-9.]*\\([A-Z._0-9]*\\)\\(64bit\\)$
 
 # Version
 %define ver_major _TMPL_VER_MAJOR

--- a/jllama/vespa-jllama.spec.tmpl
+++ b/jllama/vespa-jllama.spec.tmpl
@@ -8,6 +8,11 @@
 
 %global debug_package %{nil}
 
+# Don't provide shared library or pkgconfig
+%global __provides_exclude ^(lib.*\\.so\\.[0-9]*\\(\\)\\(64bit\\)|(cmake|pkgconfig)\\(.*)$
+
+%global __requires_exclude ^lib.*lama\.so\\.[0-9.]*\\([A-Z._0-9]*\\)\\(64bit\\)$
+
 # Version
 %define ver_major _TMPL_VER_MAJOR
 %define ver_minor _TMPL_VER_MINOR

--- a/jllama/vespa-jllama.spec.tmpl
+++ b/jllama/vespa-jllama.spec.tmpl
@@ -9,7 +9,7 @@
 %global debug_package %{nil}
 
 # Don't provide shared library or pkgconfig
-%global __provides_exclude ^(lib.*\\.so\\.[0-9]*\\(\\)\\(64bit\\)|(cmake|pkgconfig)\\(.*)$
+%global __provides_exclude ^(lib.*\\.so[0-9.]*\\(\\)\\(64bit\\)|(cmake|pkgconfig)\\(.*)$
 
 %global __requires_exclude ^lib(jllama|llama|openblas|openblasp)\.so[0-9.]*\\([A-Z._0-9]*\\)\\(64bit\\)$
 

--- a/jllama/vespa-jllama.spec.tmpl
+++ b/jllama/vespa-jllama.spec.tmpl
@@ -14,6 +14,8 @@
 %define ver_patch _TMPL_VER_PATCH
 %define ver_release _TMPL_VER_RELEASE
 
+%global _vespa_openblas_version 0.3.27
+
 Summary:        Native part of Java Bindings for llama.cpp
 Name:           vespa-jllama
 Version:        %{ver_major}.%{ver_minor}.%{ver_patch}
@@ -50,6 +52,9 @@ BuildRequires: vespa-cmake
 BuildRequires: make
 BuildRequires: git
 
+BuildRequires: vespa-openblas-devel >= %{_vespa_openblas_version}
+Requires: vespa-openblas >= %{_vespa_openblas_version}
+
 %global _vespa_3rdparty_deps_packaging_notice \
 See https://github.com/vespa-engine/vespa-3rdparty-deps for details \
 about packaging.
@@ -78,6 +83,7 @@ cmake \
     -DCMAKE_C_FLAGS_RELWITHDEBINFO="-g -O3 -DNDEBUG" \
     -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3 -DNDEBUG" \
     -DLLAMA_NATIVE=OFF \
+    -DLLAMA_BLAS=ON -DLLAMA_BLAS_VENDOR=OpenBLAS \
     ..
 VERBOSE=1 cmake --build .
 


### PR DESCRIPTION
@toregge PR
Currently gives incorrect auto generated dependencies.
Assumes there are some excludes needed.

```
Installing:
 vespa-jllama                        x86_64                       3.0.1-9.el8                          @commandline                       919 k
Installing dependencies:
 libgfortran                        x86_64                       8.5.0-20.el8.alma                       baseos                          644 k
 libquadmath                        x86_64                       8.5.0-20.el8.alma                       baseos                          171 k
 openblas                         x86_64                       0.3.15-6.el8                          appstream                         5.0 M
```

ldd also indicates something is not correct.,
 1 - Not found libopenblas.so.0.... Probably related to above issue.
 2 - Should have been libopenblasp.so.0. Incorrect linking, howto specify.

opt/vespa-deps/lib64/libllama.so:
	linux-vdso.so.1 (0x00007fff6a5a8000)
	libopenblas.so.0 => not found
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f7f9a86b000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f7f9a4e9000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f7f9a2d1000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f7f9a0b1000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f7f99cec000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f7f9af7e000)
