### PR TITLE
Require openssl-devel-engine when building cmake on new fedora versions.

### DIFF
--- a/cmake/vespa-cmake.spec.tmpl
+++ b/cmake/vespa-cmake.spec.tmpl
@@ -32,6 +32,11 @@ BuildRequires: gcc-c++
 BuildRequires: make
 BuildRequires: ccache
 BuildRequires: openssl-devel
+%if 0%{?fedora}
+%if %{fedora} > 40
+BuildRequires: openssl-devel-engine
+%endif
+%endif
 
 %global _vespa_3rdparty_deps_packaging_notice \
 See https://github.com/vespa-engine/vespa-3rdparty-deps for details \


### PR DESCRIPTION
@arnej27959 : please review
