### PR TITLE
Bump OpenSSL version to 3.1.7

### DIFF
--- a/openssl/.copr/Makefile
+++ b/openssl/.copr/Makefile
@@ -4,7 +4,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 # Version
 MAJOR=3
 MINOR=1
-PATCH=6
+PATCH=7
 RELEASE=1
 
 RPMTOPDIR=$(TOP)/rpmbuild

--- a/openssl/vespa-openssl.spec.tmpl
+++ b/openssl/vespa-openssl.spec.tmpl
@@ -30,7 +30,7 @@ Version:        %{ver_major}.%{ver_minor}.%{ver_patch}
 Release:        %{ver_release}%{?dist}
 License:        Apache License v2
 URL:            https://www.openssl.org
-Source0:        https://www.openssl.org/source/openssl-%{version}.tar.gz
+Source0:        https://github.com/openssl/openssl/releases/download/openssl-%{version}/openssl-%{version}.tar.gz
 
 
 %if 0%{?el8}%{?el9}


### PR DESCRIPTION
@aressem please review

The official download location has changed away from openssl.org to GitHub releases (old one 404s for this version), so update the URL as well—see https://github.com/openssl/openssl/discussions/25377.

