### PR TITLE
Use java-21-openjdk-devel on Fedora 42 and newer.

### DIFF
--- a/build-dependencies/vespa-build-dependencies.spec.tmpl
+++ b/build-dependencies/vespa-build-dependencies.spec.tmpl
@@ -14,6 +14,14 @@
 %global _vespa_lz4_version 1.9.4-2
 %global _vespa_toolset_version 13.1.2
 %global _vespa_openblas_version 0.3.27
+%if 0%{?fedora}
+%if %{fedora} > 41
+%global _vespa_java_version 21
+%endif
+%endif
+%if ! 0%{?_vespa_java_version:1}
+%global _vespa_java_version 17
+%endif
 
 Name:           vespa-build-dependencies
 Version:        %{ver_major}.%{ver_minor}.%{ver_patch}
@@ -116,8 +124,8 @@ Requires: maven-amazon-corretto17
 Requires: vespa-re2-devel = 20210801
 Requires: vespa-xxhash-devel >= 0.8.1
 %else
-Requires: java-17-openjdk-devel
-Requires: maven-openjdk17
+Requires: java-%{_vespa_java_version}-openjdk-devel
+Requires: maven-openjdk%{_vespa_java_version}
 Requires: re2-devel
 Requires: xxhash-devel >= 0.8.1
 %endif


### PR DESCRIPTION
@aressem : please review
