### PR TITLE
Leave the debug symbols unstripped from binary

### DIFF
--- a/wireguard-go/vespa-wireguard-go.spec.tmpl
+++ b/wireguard-go/vespa-wireguard-go.spec.tmpl
@@ -6,6 +6,9 @@
 # Force special prefix for Vespa
 %define _prefix /opt/vespa-deps
 
+# Leave the debug symbols in the binary
+%define __strip /bin/true
+
 # Version
 %define ver_major _TMPL_VER_MAJOR
 %define ver_minor _TMPL_VER_MINOR


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
