### PR TITLE
Use abseil-cpp from epel for CentOS Stream 10.

### DIFF
--- a/build-dependencies/vespa-build-dependencies.spec.tmpl
+++ b/build-dependencies/vespa-build-dependencies.spec.tmpl
@@ -101,8 +101,8 @@ Requires: cmake >= 3.30.5
 Requires: gcc-c++
 Requires: libatomic
 Requires: glibc-langpack-en
-Requires: vespa-gmock-devel = %{_vespa_gtest_version}
-Requires: vespa-gtest-devel = %{_vespa_gtest_version}
+Requires: gmock-devel
+Requires: gtest-devel
 Requires: llvm-devel
 Requires: maven
 Requires: vespa-openblas-devel >= %{_vespa_openblas_version}
@@ -110,7 +110,7 @@ Requires: openssl-devel
 Requires: vespa-libzstd-devel >= %{_vespa_libzstd_version}
 Requires: vespa-lz4-devel >= %{_vespa_lz4_version}
 Requires: vespa-onnxruntime-devel = %{_vespa_onnxruntime_version}
-Requires: vespa-abseil-cpp-devel = %{_vespa_abseil_cpp_version}
+Requires: abseil-cpp-devel
 Requires: vespa-protobuf-devel = %{_vespa_protobuf_version}
 %endif
 
@@ -131,7 +131,11 @@ Requires: llvm-devel
 Requires: maven
 Requires: vespa-openblas-devel >= %{_vespa_openblas_version}
 Requires: openssl-devel
+%if 0%{?amzn2023}
 Requires: vespa-abseil-cpp-devel = %{_vespa_abseil_cpp_version}
+%else
+Requires: abseil-cpp-devel
+%endif
 Requires: vespa-protobuf-devel = %{_vespa_protobuf_version}
 Requires: vespa-lz4-devel >= %{_vespa_lz4_version}
 Requires: vespa-onnxruntime-devel = %{_vespa_onnxruntime_version}

--- a/protobuf/vespa-protobuf.spec.tmpl
+++ b/protobuf/vespa-protobuf.spec.tmpl
@@ -17,17 +17,18 @@
 # Only strip debug info
 %global _find_debuginfo_opts -g
 
-%if 0%{?el8} || 0%{?el9} || 0%{?el10} || 0%{?amzn2023}
+%if 0%{?el8} || 0%{?el9} || 0%{?amzn2023}
 %global _use_vespa_gtest 1
 %global _vespa_gtest_version 1.14.0
-%endif
+%global _use_vespa_abseil_cpp 1
 %global _vespa_abseil_cpp_version 20240116.1
+%endif
 
 # Don't provide shared library or pkgconfig
 %global __provides_exclude ^(lib.*\\.so\\.[0-9.]*\\([A-Za-z._0-9]*\\)\\(64bit\\)|pkgconfig\\(.*)$
 
 # Exclude automated requires for libraries in /opt/vespa-deps/lib64.
-%global __requires_exclude ^(lib(protobuf|protobuf-lite|protoc|absl_[a-z_0-9]*)\\.so\\.[0-9.]*\\([A-Za-z._0-9]*\\)\\(64bit\\)|pkgconfig\\(.*)$
+%global __requires_exclude ^(lib(protobuf|protobuf-lite|protoc%{?_use_vespa_abseil_cpp:|absl_[a-z_0-9]*})\\.so\\.[0-9.]*\\([A-Za-z._0-9]*\\)\\(64bit\\)|pkgconfig\\(.*)$
 
 Summary:        Protocol Buffers for C++ runtime
 Name:           vespa-protobuf
@@ -46,10 +47,15 @@ BuildRequires: make
 BuildRequires: gcc-c++
 BuildRequires: make
 %endif
+%if 0%{?_use_vespa_abseil_cpp}
 BuildRequires: vespa-abseil-cpp-devel%{?_isa} = %{_vespa_abseil_cpp_version}
+%else
+BuildRequires: abseil-cpp-devel%{?_isa}
+%endif
 BuildRequires: cmake
 %global _cmake_prog cmake
 %global _ctest_prog ctest
+BuildRequires: which
 BuildRequires: zlib-devel
 %if 0%{?_use_vespa_gtest}
 BuildRequires: vespa-gtest-devel%{?_isa} = %{_vespa_gtest_version}
@@ -59,7 +65,11 @@ BuildRequires: gtest-devel
 BuildRequires: gmock-devel
 %endif
 Requires: zlib
+%if 0%{?_use_vespa_abseil_cpp}
 Requires: vespa-abseil-cpp%{?_isa} = %{_vespa_abseil_cpp_version}
+%else
+Requires: abseil-cpp%{?_isa}
+%endif
 
 %global _vespa_3rdparty_deps_packaging_notice \
 See https://github.com/vespa-engine/vespa-3rdparty-deps for details \
@@ -74,6 +84,11 @@ This package contains protobuf runtime library for C++.
 %package devel
 Summary:        Protocol Buffers for C++ development
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+%if 0%{?_use_vespa_abseil_cpp}
+Requires:       vespa-abseil-cpp-devel%{?_isa} = %{_vespa_abseil_cpp_version}
+%else
+Requires:       abseil-cpp-devel%{?_isa}
+%endif
 
 %description devel
 This package contains protobuf compiler for C++ and C++ headers and libraries.


### PR DESCRIPTION
Use standard abseil-cpp package for Fedora.
(re2 on CentOS Stream 10 and Fedora 41 depends on abseil-cpp).

@arnej27959 : please review
