### PR TITLE
Use python 3.11 when compiling onnxruntime on Amazon Linux 2023.

### DIFF
--- a/onnxruntime/vespa-onnxruntime.spec.tmpl
+++ b/onnxruntime/vespa-onnxruntime.spec.tmpl
@@ -86,6 +86,11 @@ BuildRequires: python3-devel
 BuildRequires: python3-numpy
 BuildRequires: python3-setuptools
 %endif
+%if 0%{?amzn2023}
+BuildRequires: python3.11
+BuildRequires: python3.11-devel
+BuildRequires: python3.11-setuptools
+%endif
 %if 0%{?fedora}
 BuildRequires: gcc-c++
 BuildRequires: make


### PR DESCRIPTION
@arnej27959 : please review
