### PR TITLE
restore "BuildRequires: git" removed by mistake

### DIFF
--- a/jllama-cuda/vespa-jllama-cuda.spec.tmpl
+++ b/jllama-cuda/vespa-jllama-cuda.spec.tmpl
@@ -41,6 +41,7 @@ BuildRequires: vespa-cmake
 BuildRequires: cmake
 %endif
 BuildRequires: make
+BuildRequires: git
 
 %define _cuda_version_major 12
 %define _cuda_version_minor 8


### PR DESCRIPTION
@toregge FYI
