### PR TITLE
Let mimalloc `.so` symlinks be part of non-devel package

### DIFF
--- a/mimalloc/.copr/Makefile
+++ b/mimalloc/.copr/Makefile
@@ -5,7 +5,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 MAJOR=2
 MINOR=2
 PATCH=4
-RELEASE=2
+RELEASE=3
 
 # Note:
 #

--- a/mimalloc/vespa-mimalloc.spec.tmpl
+++ b/mimalloc/vespa-mimalloc.spec.tmpl
@@ -99,16 +99,18 @@ cd build
 %files
 %license LICENSE
 %{_libdir}
-%exclude %{_libdir}/*.so
 %exclude %{_libdir}/*.o
 %exclude %{_libdir}/*.a
 
 %files devel
 %license LICENSE
 %{_includedir}
-%{_libdir}/*.so
+%exclude %{_libdir}/*.so
 
 %changelog
+* Fri Sep 12 2025 Tor Brede Vekterli <vekterli@vespa.ai> - 2.2.4-3
+- Let symlinked .so be part of non-devel package
+
 * Thu Jul 17 2025 Tor Brede Vekterli <vekterli@vespa.ai> - 2.2.4-2
 - Remove transitive dependency on vespa-cmake and allow custom RPATH
 


### PR DESCRIPTION
@toregge please review
@johansolbakken FYI

Used as part of `LD_PRELOAD` and not as part of regular linking, so prefer to have a non-versioned symlink `libmimalloc.so` to use as an indirection instead of having to know the actual version.


