### PR TITLE
Add dependency on `vespa-gbenchmark-devel` to `build-dependencies`

### DIFF
--- a/build-dependencies/.copr/Makefile
+++ b/build-dependencies/.copr/Makefile
@@ -4,7 +4,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 # Version
 MAJOR=1
 MINOR=6
-PATCH=2
+PATCH=3
 RELEASE=1
 PKGNAME=vespa-build-dependencies
 

--- a/build-dependencies/vespa-build-dependencies.spec.tmpl
+++ b/build-dependencies/vespa-build-dependencies.spec.tmpl
@@ -17,6 +17,7 @@
 %global _vespa_datasketches_version 5.2.0
 %global _vespa_mimalloc_version 2.2.4
 %global _vespa_highway_version 1.3.0
+%global _vespa_gbenchmark_version 1.9.4
 %if 0%{?fedora}
 %if %{fedora} > 39
 %global _vespa_java_version 21
@@ -76,6 +77,7 @@ Requires: vespa-protobuf-devel = %{_vespa_protobuf_version}
 Requires: vespa-datasketches-cpp = %{_vespa_datasketches_version}
 Requires: vespa-mimalloc-devel = %{_vespa_mimalloc_version}
 Requires: vespa-highway-devel = %{_vespa_highway_version}
+Requires: vespa-gbenchmark-devel = %{_vespa_gbenchmark_version}
 Requires: vespa-toolset-14-meta >= %{_vespa_toolset_version}
 %endif
 
@@ -102,6 +104,7 @@ Requires: vespa-protobuf-devel = %{_vespa_protobuf_version}
 Requires: vespa-datasketches-cpp = %{_vespa_datasketches_version}
 Requires: vespa-mimalloc-devel = %{_vespa_mimalloc_version}
 Requires: vespa-highway-devel = %{_vespa_highway_version}
+Requires: vespa-gbenchmark-devel = %{_vespa_gbenchmark_version}
 Requires: vespa-toolset-14-meta >= %{_vespa_toolset_version}
 %endif
 
@@ -126,6 +129,7 @@ Requires: vespa-protobuf-devel = %{_vespa_protobuf_version}
 Requires: vespa-datasketches-cpp = %{_vespa_datasketches_version}
 Requires: vespa-mimalloc-devel = %{_vespa_mimalloc_version}
 Requires: vespa-highway-devel = %{_vespa_highway_version}
+Requires: vespa-gbenchmark-devel = %{_vespa_gbenchmark_version}
 
 %endif
 
@@ -162,6 +166,7 @@ Requires: vespa-libzstd-devel >= %{_vespa_libzstd_version}
 Requires: vespa-datasketches-cpp = %{_vespa_datasketches_version}
 Requires: vespa-mimalloc-devel = %{_vespa_mimalloc_version}
 Requires: vespa-highway-devel = %{_vespa_highway_version}
+Requires: vespa-gbenchmark-devel = %{_vespa_gbenchmark_version}
 %endif
 
 # For Amazon Linux 2023 fedora is also defined
@@ -185,6 +190,9 @@ Vespa - The open big data serving engine - build dependencies
 %files
 
 %changelog
+* Fri Sep 12 2025 Tor Brede Vekterli <vekterli@vespa.ai> 1.6.3
+- Add dependency on vespa-gbenchmark-devel 1.9.4
+
 * Wed Aug 27 2025 Tor Brede Vekterli <vekterli@vespa.ai> 1.6.2
 - Add dependency on vespa-mimalloc-devel 2.2.4
 - Add dependency on vespa-highway-devel 1.3.0


### PR DESCRIPTION
@toregge please review
