### PR TITLE
Use OpenSSL 3.5.4 LTS

### DIFF
--- a/openssl/.copr/Makefile
+++ b/openssl/.copr/Makefile
@@ -3,9 +3,9 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Version
 MAJOR=3
-MINOR=1
-PATCH=8
-RELEASE=2
+MINOR=5
+PATCH=4
+RELEASE=1
 
 # The actual name for the generated (base) package
 PKGNAME=vespa-openssl


### PR DESCRIPTION
@arnej27959 please review

3.1 branch is EOL, first LTS is 3.5.

This also implicitly enables post-quantum key exchanges, which hopefully won't cause noticeable latency elevations... 👀

Have previously manually tested building+running Vespa with the 3.5 branch, no code changes should be required.