### PR TITLE
Upgrade abseil-cpp 20250127→20260107 and protobuf 5.30.1→6.34.1

### DIFF
--- a/abseil-cpp/.copr/Makefile
+++ b/abseil-cpp/.copr/Makefile
@@ -5,7 +5,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 MAJOR=20260107
 MINOR=1
 PATCH=0
-RELEASE=3
+RELEASE=4
 
 # Note:
 #

--- a/abseil-cpp/.copr/Makefile
+++ b/abseil-cpp/.copr/Makefile
@@ -2,7 +2,7 @@
 TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Version
-MAJOR=20250127
+MAJOR=20260107
 MINOR=1
 PATCH=0
 RELEASE=2

--- a/abseil-cpp/.copr/Makefile
+++ b/abseil-cpp/.copr/Makefile
@@ -5,7 +5,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 MAJOR=20260107
 MINOR=1
 PATCH=0
-RELEASE=2
+RELEASE=3
 
 # Note:
 #

--- a/abseil-cpp/vespa-abseil-cpp.spec.tmpl
+++ b/abseil-cpp/vespa-abseil-cpp.spec.tmpl
@@ -174,5 +174,8 @@ env DESTDIR="%{buildroot}" cmake --install build
 %license LICENSE
 
 %changelog
+* Thu Mar 26 2026 Arne Juul
+- Track upstream release of abseil-cpp 20260107
+
 * Tue Mar 18 2025 Tor Egge <Tor.Egge@online.no> - 20250127.1
 - Track upstream release of abseil-cpp 20250127.1

--- a/abseil-cpp/vespa-abseil-cpp.spec.tmpl
+++ b/abseil-cpp/vespa-abseil-cpp.spec.tmpl
@@ -44,6 +44,9 @@ BuildRequires: gcc-c++
 BuildRequires: make
 BuildRequires: cmake
 %endif
+%if 0%{?el10}
+BuildRequires: patchelf
+%endif
 %if 0%{?_use_vespa_gtest}
 BuildRequires: vespa-gtest-devel%{?_isa} = %{_vespa_gtest_version}
 BuildRequires: vespa-gmock-devel%{?_isa} = %{_vespa_gtest_version}
@@ -129,6 +132,10 @@ source %{_devtoolset_enable} || true
 # PATH to vespa-cmake etc
 PATH=%{_prefix}/bin:$PATH
 env DESTDIR="%{buildroot}" cmake --install build
+
+%if 0%{?el10}
+patchelf --set-rpath '$ORIGIN' %{buildroot}/%{_libdir}/*.so.*
+%endif
 
 %files
 %dir %{_libdir}

--- a/abseil-cpp/vespa-abseil-cpp.spec.tmpl
+++ b/abseil-cpp/vespa-abseil-cpp.spec.tmpl
@@ -15,6 +15,9 @@
 %global _use_vespa_gtest 1
 %global _vespa_gtest_version 1.16.0
 %endif
+%if 0%{?amzn2023}
+%global _cmake_extra_options -DCMAKE_C_COMPILER=gcc14-gcc -DCMAKE_CXX_COMPILER=gcc14-g++
+%endif
 
 # Don't provide shared library or pkgconfig
 %global __provides_exclude ^(lib.*\\.so\\.[0-9.]*\\([A-Za-z._0-9]*\\)\\(64bit\\)|pkgconfig\\(.*)$
@@ -40,7 +43,12 @@ BuildRequires: make
 BuildRequires: vespa-cmake
 %endif
 %if 0%{?el10} || 0%{?fedora}
+%if 0%{?amzn2023}
+BuildRequires: gcc14-c++
+BuildRequires: vespa-gcc14-annobin-plugin
+%else
 BuildRequires: gcc-c++
+%endif
 BuildRequires: make
 BuildRequires: cmake
 %endif
@@ -115,6 +123,7 @@ mkdir build
     -DABSL_FIND_GOOGLETEST=ON \
     -DABSL_PROPAGATE_CXX_STD=ON \
     -DCMAKE_CXX_STANDARD=20 \
+    %{?_cmake_extra_options} \
     -S . \
     -B build
 

--- a/build-dependencies/.copr/Makefile
+++ b/build-dependencies/.copr/Makefile
@@ -3,7 +3,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Version
 MAJOR=1
-MINOR=9
+MINOR=10
 PATCH=0
 RELEASE=1
 PKGNAME=vespa-build-dependencies

--- a/build-dependencies/vespa-build-dependencies.spec.tmpl
+++ b/build-dependencies/vespa-build-dependencies.spec.tmpl
@@ -6,9 +6,9 @@
 %define ver_patch _TMPL_VER_PATCH
 %define ver_release _TMPL_VER_RELEASE
 
-%global _vespa_abseil_cpp_version 20250127.1
+%global _vespa_abseil_cpp_version 20260107.1
 %global _vespa_gtest_version 1.16.0
-%global _vespa_protobuf_version 5.30.1
+%global _vespa_protobuf_version 6.34.1
 %global _vespa_onnxruntime_version 1.23.2
 %global _vespa_libzstd_version 1.5.6-1
 %global _vespa_lz4_version 1.9.4-2
@@ -177,6 +177,9 @@ Vespa - The open big data serving engine - build dependencies
 %files
 
 %changelog
+* Thu Mar 26 2026 Arne Juul
+- New versions of abseil and protobuf
+
 * Fri Sep 12 2025 Tor Brede Vekterli <vekterli@vespa.ai> 1.6.3
 - Add dependency on vespa-gbenchmark-devel 1.9.4
 

--- a/protobuf/.copr/Makefile
+++ b/protobuf/.copr/Makefile
@@ -5,7 +5,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 MAJOR=6
 MINOR=34
 PATCH=1
-RELEASE=1
+RELEASE=2
 
 # Note:
 #

--- a/protobuf/.copr/Makefile
+++ b/protobuf/.copr/Makefile
@@ -2,10 +2,10 @@
 TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Version
-MAJOR=5
-MINOR=30
+MAJOR=6
+MINOR=34
 PATCH=1
-RELEASE=3
+RELEASE=1
 
 # Note:
 #

--- a/protobuf/vespa-protobuf.spec.tmpl
+++ b/protobuf/vespa-protobuf.spec.tmpl
@@ -27,7 +27,7 @@
 %global _use_vespa_gtest 1
 %global _vespa_gtest_version 1.16.0
 %global _use_vespa_abseil_cpp 1
-%global _vespa_abseil_cpp_version 20250127.1
+%global _vespa_abseil_cpp_version 20260107.1
 %endif
 
 # Don't provide shared library or pkgconfig
@@ -92,6 +92,7 @@ This package contains protobuf runtime library for C++.
 %package devel
 Summary:        Protocol Buffers for C++ development
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       %{name}-upb%{?_isa} = %{version}-%{release}
 %if 0%{?_use_vespa_abseil_cpp}
 Requires:       vespa-abseil-cpp-devel%{?_isa} = %{_vespa_abseil_cpp_version}
 %else
@@ -101,6 +102,18 @@ Requires:       abseil-cpp-devel%{?_isa}
 %description devel
 This package contains protobuf compiler for C++ and C++ headers and libraries.
 %{_vespa_3rdparty_deps_packaging_notice}
+
+%package upb
+Summary:        micro-protobuf library
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+%if 0%{?_use_vespa_abseil_cpp}
+Requires:       vespa-abseil-cpp-devel%{?_isa} = %{_vespa_abseil_cpp_version}
+%else
+Requires:       abseil-cpp-devel%{?_isa}
+%endif
+
+%description upb
+This package contains the micro-protobuf library (libupb) for static linking.
 
 %prep
 %setup -q -n protobuf-%{ver_minor}.%{ver_patch}
@@ -114,16 +127,16 @@ PATH=%{_prefix}/bin:$PATH
 
 mkdir build
 %{_cmake_prog} \
+   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
    -DCMAKE_INSTALL_PREFIX=%{_prefix} \
-   -DCMAKE_INSTALL_RPATH=%{_libdir} \
+   -DCMAKE_INSTALL_RPATH='$ORIGIN' \
    -DCMAKE_PREFIX_PATH=%{_prefix} \
    -DCMAKE_BUILD_WITH_INSTALL_RPATH=false \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-   -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3" \
+   -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3 -Wno-deprecated-declarations" \
    -DBUILD_SHARED_LIBS=ON \
    -DCMAKE_CXX_STANDARD=23 \
    -Dprotobuf_LOCAL_DEPENDENCIES_ONLY=ON \
-   -Dprotobuf_BUILD_LIBUPB=OFF \
    -S . \
    -B build
 
@@ -167,6 +180,15 @@ DESTDIR="%{buildroot}" %{_cmake_prog} --install build
 %{_bindir}/protoc-%{version_suffix}
 %license LICENSE
 
+%files upb
+%{_bindir}/protoc-gen-upb*
+%{_libdir}/libupb.a
+%{_includedir}/upb
+%license LICENSE
+
 %changelog
+* Thu Mar 26 2026 Arne Juul - 6.34.1
+- Track upstream release of protobuf 34.1
+
 * Tue Mar 18 2025 Tor Egge <Tor.Egge@online.no> - 5.30.1
 - Track upstream release of protobuf 30.1

--- a/protobuf/vespa-protobuf.spec.tmpl
+++ b/protobuf/vespa-protobuf.spec.tmpl
@@ -29,6 +29,9 @@
 %global _use_vespa_abseil_cpp 1
 %global _vespa_abseil_cpp_version 20260107.1
 %endif
+%if 0%{?amzn2023}
+%global _cmake_extra_options -DCMAKE_C_COMPILER=gcc14-gcc -DCMAKE_CXX_COMPILER=gcc14-g++
+%endif
 
 # Don't provide shared library or pkgconfig
 %global __provides_exclude ^(lib.*\\.so\\.[0-9.]*\\([A-Za-z._0-9]*\\)\\(64bit\\)|pkgconfig\\(.*)$
@@ -53,7 +56,12 @@ BuildRequires: vespa-cmake
 BuildRequires: cmake
 %endif
 %if 0%{?el10} || 0%{?fedora}
+%if 0%{?amzn2023}
+BuildRequires: gcc14-c++
+BuildRequires: vespa-gcc14-annobin-plugin
+%else
 BuildRequires: gcc-c++
+%endif
 BuildRequires: make
 %endif
 %if 0%{?_use_vespa_abseil_cpp}
@@ -136,6 +144,7 @@ mkdir build
    -DBUILD_SHARED_LIBS=ON \
    -DCMAKE_CXX_STANDARD=23 \
    -Dprotobuf_LOCAL_DEPENDENCIES_ONLY=ON \
+    %{?_cmake_extra_options} \
    -S . \
    -B build
 

--- a/protobuf/vespa-protobuf.spec.tmpl
+++ b/protobuf/vespa-protobuf.spec.tmpl
@@ -127,7 +127,6 @@ PATH=%{_prefix}/bin:$PATH
 
 mkdir build
 %{_cmake_prog} \
-   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
    -DCMAKE_INSTALL_PREFIX=%{_prefix} \
    -DCMAKE_INSTALL_RPATH='$ORIGIN' \
    -DCMAKE_PREFIX_PATH=%{_prefix} \


### PR DESCRIPTION
abseil-cpp: track new upstream release 20260107.

protobuf: major version bump to 6.34.1. protobuf 6.x requires libupb, so removed -Dprotobuf_BUILD_LIBUPB=OFF and added a new vespa-protobuf-upb subpackage containing libupb.a and upb headers. The devel package now depends on upb. Also: switch RPATH to $ORIGIN (relative), enable ccache, and suppress -Wno-deprecated-declarations for the new version.

build-dependencies: update version refs for abseil and protobuf, bump MINOR to 10.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
