### PR TITLE
wireguard-go: upgrade Go 1.26.0 -> 1.26.2, refresh module deps

### DIFF
--- a/wireguard-go/.copr/Makefile
+++ b/wireguard-go/.copr/Makefile
@@ -5,7 +5,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 MAJOR=0
 MINOR=0
 PATCH=20250522
-RELEASE=1
+RELEASE=2
 GITREF=f333402bd9cbe0f3eeb02507bd14e23d7d639280
 
 # The actual name for the generated package

--- a/wireguard-go/vespa-wireguard-go.spec.tmpl
+++ b/wireguard-go/vespa-wireguard-go.spec.tmpl
@@ -16,7 +16,7 @@
 %define ver_release _TMPL_VER_RELEASE
 %define gitref _TMPL_GITREF
 
-%define go_version 1.26.0
+%define go_version 1.26.2
 
 Summary:        Wireguard-go
 Name:           vespa-wireguard-go
@@ -44,6 +44,8 @@ go install golang.org/dl/go%{go_version}@latest
 go%{go_version} download
 PATH=$HOME/sdk/go%{go_version}/bin/:$PATH
 go version
+go get -u ./...
+go mod tidy
 go env -w GOPROXY="https://proxy.golang.org,direct"
 make
 grep crypto go.mod


### PR DESCRIPTION
Bump the Go toolchain used to build vespa-wireguard-go from 1.26.0 to 1.26.2 (patch release with bug fixes).

Add `go get -u ./...` and `go mod tidy` to the RPM build steps so that Go module dependencies are updated to their latest compatible versions at build time, keeping the wireguard-go package current with upstream.

Bump RELEASE to 2 to reflect the spec change.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
