### PR TITLE
Add -DNDEBUG to protobuf RelWithDebInfo build flags

### DIFF
--- a/protobuf/.copr/Makefile
+++ b/protobuf/.copr/Makefile
@@ -5,7 +5,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 MAJOR=6
 MINOR=34
 PATCH=1
-RELEASE=5
+RELEASE=6
 
 # Note:
 #

--- a/protobuf/vespa-protobuf.spec.tmpl
+++ b/protobuf/vespa-protobuf.spec.tmpl
@@ -149,7 +149,7 @@ mkdir build
    -DCMAKE_PREFIX_PATH=%{_prefix} \
    -DCMAKE_BUILD_WITH_INSTALL_RPATH=false \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-   -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="%{_arch_cmake_options} -g -O3 -Wno-deprecated-declarations" \
+   -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="%{_arch_cmake_options} -g -O3 -DNDEBUG -Wno-deprecated-declarations" \
    -DBUILD_SHARED_LIBS=ON \
    -DCMAKE_CXX_STANDARD=23 \
    -Dprotobuf_LOCAL_DEPENDENCIES_ONLY=ON \


### PR DESCRIPTION
The spec overrides CMAKE_CXX_FLAGS_RELWITHDEBINFO with custom flags, which replaces CMake's defaults entirely. This meant -DNDEBUG was missing, leaving assert() macros active in the release build. Add the flag explicitly and bump release to 6.
