### PR TITLE
Upgrade to GCC 15 toolset on el9/el10 and Java 25 on el10

### DIFF
--- a/build-dependencies/.copr/Makefile
+++ b/build-dependencies/.copr/Makefile
@@ -3,7 +3,7 @@ TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Version
 MAJOR=1
-MINOR=11
+MINOR=12
 PATCH=0
 RELEASE=1
 PKGNAME=vespa-build-dependencies

--- a/build-dependencies/vespa-build-dependencies.spec.tmpl
+++ b/build-dependencies/vespa-build-dependencies.spec.tmpl
@@ -8,7 +8,7 @@
 
 %global _vespa_abseil_cpp_version 20260107.1.1
 %global _vespa_gtest_version 1.16.0
-%global _vespa_protobuf_version 6.34.1-5
+%global _vespa_protobuf_version 6.34.1
 %global _vespa_onnxruntime_version 1.23.2
 %global _vespa_libzstd_version 1.5.6-1
 %global _vespa_lz4_version 1.9.4-2
@@ -28,7 +28,10 @@
 %endif
 %endif
 %endif
-%if 0%{?el10} || 0%{?el9}
+%if 0%{?el10}
+%global _vespa_java_version 25
+%endif
+%if 0%{?el9}
 %global _vespa_java_version 21
 %endif
 %if ! 0%{?_vespa_java_version:1}
@@ -88,7 +91,7 @@ Requires: vespa-gmock-devel = %{_vespa_gtest_version}
 Requires: vespa-gtest-devel = %{_vespa_gtest_version}
 Requires: vespa-lz4-devel >= %{_vespa_lz4_version}
 Requires: vespa-abseil-cpp-devel = %{_vespa_abseil_cpp_version}
-Requires: vespa-protobuf-devel >= %{_vespa_protobuf_version}
+Requires: vespa-protobuf-devel = %{_vespa_protobuf_version}
 Requires: vespa-toolset-14-meta >= %{_vespa_toolset_version}
 Requires: maven-openjdk%{_vespa_java_version}
 %endif
@@ -96,9 +99,10 @@ Requires: maven-openjdk%{_vespa_java_version}
 %if 0%{?el9}
 %global _centos_stream %(grep -qs '^NAME="CentOS Stream"' /etc/os-release && echo 1 || echo 0)
 Requires: vespa-cmake >= 3.29.1
-Requires: gcc-toolset-14-gcc-c++
-Requires: gcc-toolset-14-binutils
-Requires: gcc-toolset-14-libatomic-devel
+Requires: gcc-toolset-15-gcc-c++
+Requires: gcc-toolset-15-binutils
+Requires: gcc-toolset-15-libatomic-devel
+# Note: gcc-toolset-15-dwz is not available for some reason.
 Requires: gcc-toolset-14-dwz
 Requires: glibc-langpack-en
 Requires: vespa-gmock-devel = %{_vespa_gtest_version}
@@ -109,14 +113,18 @@ Requires: openssl-devel
 Requires: vespa-libzstd-devel >= %{_vespa_libzstd_version}
 Requires: vespa-lz4-devel >= %{_vespa_lz4_version}
 Requires: vespa-abseil-cpp-devel = %{_vespa_abseil_cpp_version}
-Requires: vespa-protobuf-devel >= %{_vespa_protobuf_version}
-Requires: vespa-toolset-14-meta >= %{_vespa_toolset_version}
+Requires: vespa-protobuf-devel = %{_vespa_protobuf_version}
+Requires: vespa-toolset-15-meta
 Requires: maven-openjdk%{_vespa_java_version}
 %endif
 
 %if 0%{?el10}
 %global _centos_stream %(grep -qs '^NAME="CentOS Stream"' /etc/os-release && echo 1 || echo 0)
 Requires: cmake >= 3.30.5
+Requires: gcc-toolset-15-gcc-c++
+Requires: gcc-toolset-15-binutils
+Requires: gcc-toolset-15-libatomic-devel
+Requires: vespa-toolset-15-meta
 Requires: gcc-c++
 Requires: libatomic
 Requires: glibc-langpack-en
@@ -128,7 +136,7 @@ Requires: openssl-devel
 Requires: vespa-libzstd-devel >= %{_vespa_libzstd_version}
 Requires: vespa-lz4-devel >= %{_vespa_lz4_version}
 Requires: abseil-cpp-devel
-Requires: vespa-protobuf-devel >= %{_vespa_protobuf_version}
+Requires: vespa-protobuf-devel = %{_vespa_protobuf_version}
 Requires: maven-openjdk%{_vespa_java_version}
 %endif
 
@@ -157,7 +165,7 @@ Requires: vespa-abseil-cpp-devel = %{_vespa_abseil_cpp_version}
 %else
 Requires: abseil-cpp-devel
 %endif
-Requires: vespa-protobuf-devel >= %{_vespa_protobuf_version}
+Requires: vespa-protobuf-devel = %{_vespa_protobuf_version}
 Requires: vespa-lz4-devel >= %{_vespa_lz4_version}
 Requires: vespa-libzstd-devel >= %{_vespa_libzstd_version}
 %endif


### PR DESCRIPTION
Move el9 from gcc-toolset-14 to gcc-toolset-15 for gcc-c++, binutils, and libatomic-devel. Add gcc-toolset-15 packages to el10 as well.

Switch el10 from Java 21 to Java 25 to match the newer platform.

Also pin vespa-protobuf-devel to exact version (= instead of >=) on all platforms.

Note: I'm leaning towards doing gcc 15 on EL8 as its own step.