### PR TITLE
Bump mimalloc to v3.3.2

### DIFF
--- a/mimalloc/.copr/Makefile
+++ b/mimalloc/.copr/Makefile
@@ -2,10 +2,10 @@
 TOP = $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Version
-MAJOR=2
-MINOR=2
-PATCH=4
-RELEASE=4
+MAJOR=3
+MINOR=3
+PATCH=2
+RELEASE=1
 
 # Note:
 #


### PR DESCRIPTION
@arnej27959 please review
@hmusum FYI

`vespa.spec` has an exact version dependency on v2.2.4, so the stale RPM version GC clock starts ticking once we build new RPMs on Copr... So probably best to hold off until next week.